### PR TITLE
feat/re-structure-results: Restructure output bucket structure before…

### DIFF
--- a/src/main/kotlin/org/entur/ror/ubelluris/UbellurisApplication.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/UbellurisApplication.kt
@@ -9,6 +9,8 @@ import org.entur.ror.ubelluris.timetable.TimetableProcessor
 import org.entur.ror.ubelluris.timetable.config.TimetableConfig
 import org.entur.ror.ubelluris.timetable.fetch.GcsTimetableFetcher
 import java.io.File
+import java.time.LocalDate
+import kotlin.io.path.Path
 import kotlin.system.exitProcess
 
 fun main(args: Array<String>) {
@@ -30,6 +32,9 @@ fun main(args: Array<String>) {
     val bucketService = UbellurisBucketService(gcsConfig)
     val storage = bucketService.createStorage()
 
+    val today = LocalDate.now()
+    val stopPlaceStoragePath = Path("${today.year}", "%02d".format(today.monthValue), "%02d".format(today.dayOfMonth), "stops")
+
     val timetableConfig = TimetableConfig(
         providers = cliConfig.timetableProviders,
         modeFilter = cliConfig.transportModes.toSet(),
@@ -40,13 +45,13 @@ fun main(args: Array<String>) {
     val timetableProcessor = TimetableProcessor(timetableFetcher, timetableConfig)
 
     UbellurisService(
-        fetcher = GcsFileFetcher(storage, gcsConfig.inputBucketName),
+        fetcher = GcsFileFetcher(storage, gcsConfig.inputBucketName, stopPlaceStoragePath),
         processor = FilterService(
             cliConfig = cliConfig,
             timetableProcessor = timetableProcessor,
             blacklistFilePath = blacklistFilePath
         ),
-        publisher = bucketService.createPublisher()
+        publisher = bucketService.createPublisher(stopPlaceStoragePath)
     ).run()
 }
 

--- a/src/main/kotlin/org/entur/ror/ubelluris/file/GcsFileFetcher.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/file/GcsFileFetcher.kt
@@ -1,14 +1,11 @@
 package org.entur.ror.ubelluris.file
 
-import com.google.cloud.storage.Blob
 import com.google.cloud.storage.Storage
 import org.slf4j.LoggerFactory
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
 import java.util.zip.ZipInputStream
-
-fun Storage.get(bucketName: String, blobPath: Path): Blob? = this.get(bucketName, blobPath.joinToString("/"))
 
 class GcsFileFetcher(
     private val storage: Storage,
@@ -31,7 +28,7 @@ class GcsFileFetcher(
         val blobPath = storagePath.resolve("sweden.zip")
         logger.info("Fetching stops data from GCS: $inputBucketName/$blobPath")
 
-        val blob = storage.get(inputBucketName, blobPath)
+        val blob = storage.get(inputBucketName, blobPath.joinToString("/"))
             ?: error("Blob not found: $inputBucketName/$blobPath")
 
         val zipBytes = blob.getContent()

--- a/src/main/kotlin/org/entur/ror/ubelluris/file/GcsFileFetcher.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/file/GcsFileFetcher.kt
@@ -1,32 +1,34 @@
 package org.entur.ror.ubelluris.file
 
+import com.google.cloud.storage.Blob
 import com.google.cloud.storage.Storage
 import org.slf4j.LoggerFactory
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
-import java.time.LocalDate
 import java.util.zip.ZipInputStream
+
+fun Storage.get(bucketName: String, blobPath: Path): Blob? = this.get(bucketName, blobPath.joinToString("/"))
 
 class GcsFileFetcher(
     private val storage: Storage,
     private val inputBucketName: String,
+    private val storagePath: Path,
     private val downloadDir: Path = Path.of("downloads")
 ) : FileFetcher {
     private val logger = LoggerFactory.getLogger(javaClass)
 
     override fun fetch(): Path {
-        val today = LocalDate.now()
-        val outputPath = downloadDir.resolve("${today}_stop_places.xml")
+        val outputPath = downloadDir.resolve(storagePath).resolve("sweden_stop_places.xml")
 
         Files.createDirectories(downloadDir)
 
         if (Files.exists(outputPath)) {
-            logger.info("Found existing download for $today: $outputPath")
+            logger.info("Found existing download for $outputPath")
             return outputPath
         }
 
-        val blobPath = "${today.year}/${"%02d".format(today.monthValue)}/${"%02d".format(today.dayOfMonth)}/stops/sweden.zip"
+        val blobPath = storagePath.resolve("sweden.zip")
         logger.info("Fetching stops data from GCS: $inputBucketName/$blobPath")
 
         val blob = storage.get(inputBucketName, blobPath)
@@ -38,6 +40,7 @@ class GcsFileFetcher(
             var entry = zip.nextEntry
             while (entry != null) {
                 if (!entry.isDirectory && entry.name.endsWith(".xml")) {
+                    Files.createDirectories(outputPath.parent)
                     Files.write(
                         outputPath,
                         zip.readBytes(),

--- a/src/main/kotlin/org/entur/ror/ubelluris/file/UbellurisBucketService.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/file/UbellurisBucketService.kt
@@ -6,6 +6,7 @@ import org.entur.ror.ubelluris.config.GcsConfig
 import org.entur.ror.ubelluris.publish.FilePublisher
 import org.entur.ror.ubelluris.publish.GcsFilePublisher
 import org.entur.ror.ubelluris.publish.LocalFilePublisher
+import java.nio.file.Path
 
 class UbellurisBucketService(
     private val config: GcsConfig,
@@ -20,12 +21,12 @@ class UbellurisBucketService(
         return storageProvider()
     }
 
-    fun createPublisher(): FilePublisher {
+    fun createPublisher(storagePath: Path): FilePublisher {
         if (config.gcsEnabled) {
             val storage = createStorage()
-            return GcsFilePublisher(config, storage)
+            return GcsFilePublisher(config, storage, storagePath)
         }
 
-        return LocalFilePublisher()
+        return LocalFilePublisher(storagePath)
     }
 }

--- a/src/main/kotlin/org/entur/ror/ubelluris/publish/GcsFilePublisher.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/publish/GcsFilePublisher.kt
@@ -10,14 +10,15 @@ import java.nio.file.Path
 
 class GcsFilePublisher(
     private val config: GcsConfig,
-    private val storage: Storage
+    private val storage: Storage,
+    private val storagePath: Path
 ) : FilePublisher {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
     override fun publish(file: Path): Path {
-        val blobName = file.fileName.toString()
-        val blobId = BlobId.of(config.bucketName, blobName)
+        val blobName = storagePath.resolve(file.fileName)
+        val blobId = BlobId.of(config.bucketName, blobName.joinToString("/"))
         val blobInfo = BlobInfo.newBuilder(blobId).build()
 
         logger.info("Uploading filtered file to Ubelluris bucket")
@@ -26,6 +27,6 @@ class GcsFilePublisher(
         }
 
         logger.info("Successfully uploaded filtered file to Ubelluris bucket.")
-        return Path.of("${config.bucketName}/${blobName}")
+        return Path.of(config.bucketName).resolve(blobName)
     }
 }

--- a/src/main/kotlin/org/entur/ror/ubelluris/publish/LocalFilePublisher.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/publish/LocalFilePublisher.kt
@@ -5,13 +5,15 @@ import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 
 class LocalFilePublisher(
+    private val storagePath: Path,
     private val resultsDir: Path = Path.of("results")
 ) : FilePublisher {
 
     override fun publish(file: Path): Path {
-        Files.createDirectories(resultsDir)
+        val targetDir = resultsDir.resolve(storagePath)
+        Files.createDirectories(targetDir)
 
-        val targetFile = resultsDir.resolve(file.fileName)
+        val targetFile = targetDir.resolve(file.fileName)
 
         Files.move(
             file,

--- a/src/test/kotlin/org/entur/ror/ubelluris/publish/GcsFilePublisherTest.kt
+++ b/src/test/kotlin/org/entur/ror/ubelluris/publish/GcsFilePublisherTest.kt
@@ -7,11 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.entur.ror.ubelluris.config.GcsConfig
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
-import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
+import org.mockito.kotlin.*
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
@@ -27,15 +23,17 @@ class GcsFilePublisherTest {
 
     private val mockStorage: Storage = mock()
     private val mockBlob: Blob = mock()
+    private val storagePath = Path.of("2026", "01", "01", "stops")
 
-    private val filePublisher = GcsFilePublisher(config, mockStorage)
+    private val filePublisher = GcsFilePublisher(config, mockStorage, storagePath)
 
     @TempDir
     lateinit var tempDir: Path
 
     @Test
     fun shouldPublishFile() {
-        val xmlFile = tempDir.resolve("file_to_publish.xml")
+        val xmlFile = tempDir.resolve(storagePath).resolve("file_to_publish.xml")
+        Files.createDirectories(xmlFile.parent)
 
         Files.writeString(
             xmlFile,
@@ -56,7 +54,7 @@ class GcsFilePublisherTest {
 
         val result = filePublisher.publish(xmlFile)
 
-        assertThat(result).isEqualTo(Path.of("test-bucket/file_to_publish.xml"))
+        assertThat(result).isEqualTo(Path.of("test-bucket/2026/01/01/stops/file_to_publish.xml"))
     }
 
     @Test
@@ -73,6 +71,6 @@ class GcsFilePublisherTest {
 
         val capturedBlobInfo = blobInfoCaptor.firstValue
         assertThat(capturedBlobInfo.bucket).isEqualTo("test-bucket")
-        assertThat(capturedBlobInfo.name).isEqualTo("test_file.xml")
+        assertThat(capturedBlobInfo.name).isEqualTo("2026/01/01/stops/test_file.xml")
     }
 }


### PR DESCRIPTION
… timetable data is added

Old structure "/<date>_stop_place_transformed.xml", new structure "YYYY/MM/DD/stops/sweden_stop_place_transformed.xml". With timetables we'll introduce a timetable folder