### PR TITLE
feat/optional-upload-download: Split GcsEnabled into upload and download

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,15 @@ Ubelluris fetches input data from and can publish results to Google Cloud Storag
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `GCS_PROJECT_ID` | Yes | GCP project ID |
-| `GCS_INPUT_BUCKET` | Yes | Source GCS bucket containing stop place and timetable data |
+| `GCS_PROJECT_ID` | When GCS enabled | GCP project ID |
+| `GCS_INPUT_BUCKET` | When download enabled | Source GCS bucket containing stop place and timetable data |
+| `GCS_DOWNLOAD_ENABLED` | No | Set to `false` to skip GCS download and use local cache (default: `true`) |
 | `GCS_UPLOAD_ENABLED` | No | Set to `true` to enable GCS publishing (default: `false`) |
-| `GCS_BUCKET_NAME` | When upload enabled | Target GCS bucket for publishing results |
+| `GCS_OUTPUT_BUCKET` | When upload enabled | Target GCS bucket for publishing results |
 
 ### Behavior
 
-- Input data (stops and timetables) is always fetched from the `GCS_INPUT_BUCKET`
-- **Upload enabled**: Result files are uploaded to the specified `GCS_BUCKET_NAME`
+- **Download enabled** (default): Input data is fetched from `GCS_INPUT_BUCKET`; already-cached files are skipped
+- **Download disabled**: Local cache in `downloads/` is used directly, requires unzipped files; no GCS connection needed for input
+- **Upload enabled**: Result files are uploaded to the specified `GCS_OUTPUT_BUCKET`
 - **Upload disabled** (default): Result files are saved locally to a `results/` directory

--- a/src/main/kotlin/org/entur/ror/ubelluris/UbellurisApplication.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/UbellurisApplication.kt
@@ -4,8 +4,7 @@ import org.entur.ror.ubelluris.config.GcsConfig
 import org.entur.ror.ubelluris.config.JsonConfig
 import org.entur.ror.ubelluris.file.FilePublisher.Companion.STOPS_DIR
 import org.entur.ror.ubelluris.file.FilePublisher.Companion.TIMETABLE_DIR
-import org.entur.ror.ubelluris.file.GcsFileFetcher
-import org.entur.ror.ubelluris.file.UbellurisBucketService
+import org.entur.ror.ubelluris.file.FileService
 import org.entur.ror.ubelluris.filter.StopPlaceFilterService
 import org.entur.ror.ubelluris.filter.TimetableFilterService
 import java.io.File
@@ -29,8 +28,7 @@ fun main(args: Array<String>) {
     val blacklistFilePath = args.getOrElse(1) { "" }
 
     val gcsConfig = GcsConfig.fromEnvironment()
-    val bucketService = UbellurisBucketService(gcsConfig)
-    val storage = bucketService.createStorage()
+    val fileService = FileService(gcsConfig)
 
     val today = LocalDate.now()
     val storagePath = Path("${today.year}", "%02d".format(today.monthValue), "%02d".format(today.dayOfMonth))
@@ -41,20 +39,14 @@ fun main(args: Array<String>) {
         }
 
     UbellurisService(
-        fetcher =
-            GcsFileFetcher(
-                storage = storage,
-                inputBucketName = gcsConfig.inputBucketName,
-                stopPlaceBlobPath = stopPlaceBlobPath,
-                timetableBlobPaths = timetableBlobPaths,
-            ),
+        fetcher = fileService.createFetcher(stopPlaceBlobPath, timetableBlobPaths),
         timetableProcessor = TimetableFilterService(cliConfig),
         stopPlaceProcessor =
             StopPlaceFilterService(
                 cliConfig = cliConfig,
                 blacklistFilePath = blacklistFilePath,
             ),
-        publisher = bucketService.createPublisher(storagePath, Path(cliConfig.resultsDir)),
+        publisher = fileService.createPublisher(storagePath, Path(cliConfig.resultsDir)),
     ).run()
 }
 

--- a/src/main/kotlin/org/entur/ror/ubelluris/config/GcsConfig.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/config/GcsConfig.kt
@@ -4,18 +4,21 @@ data class GcsConfig(
     val projectId: String,
     val outputBucketName: String,
     val inputBucketName: String,
-    val gcsEnabled: Boolean,
+    val uploadEnabled: Boolean,
+    val downloadEnabled: Boolean,
 ) {
     companion object {
         fun fromEnvironment(): GcsConfig {
-            val enabled = System.getenv("GCS_UPLOAD_ENABLED")?.toBoolean() ?: false
+            val uploadEnabled = System.getenv("GCS_UPLOAD_ENABLED")?.toBoolean() ?: false
+            val downloadEnabled = System.getenv("GCS_DOWNLOAD_ENABLED")?.toBoolean() ?: true
 
-            if (!enabled) {
+            if (!uploadEnabled && !downloadEnabled) {
                 return GcsConfig(
                     projectId = "",
                     outputBucketName = "",
                     inputBucketName = "",
-                    gcsEnabled = false,
+                    uploadEnabled = false,
+                    downloadEnabled = false,
                 )
             }
 
@@ -23,13 +26,21 @@ data class GcsConfig(
                 System.getenv("GCS_PROJECT_ID")
                     ?: throw IllegalStateException("GCS_PROJECT_ID environment variable not set")
             val outputBucketName =
-                System.getenv("GCS_BUCKET_NAME")
-                    ?: throw IllegalStateException("GCS_BUCKET_NAME environment variable not set")
+                if (uploadEnabled) {
+                    System.getenv("GCS_OUTPUT_BUCKET")
+                        ?: throw IllegalStateException("GCS_OUTPUT_BUCKET environment variable not set")
+                } else {
+                    ""
+                }
             val inputBucketName =
-                System.getenv("GCS_INPUT_BUCKET")
-                    ?: throw IllegalStateException("GCS_INPUT_BUCKET environment variable not set")
+                if (downloadEnabled) {
+                    System.getenv("GCS_INPUT_BUCKET")
+                        ?: throw IllegalStateException("GCS_INPUT_BUCKET environment variable not set")
+                } else {
+                    ""
+                }
 
-            return GcsConfig(projectId, outputBucketName, inputBucketName, enabled)
+            return GcsConfig(projectId, outputBucketName, inputBucketName, uploadEnabled, downloadEnabled)
         }
     }
 }

--- a/src/main/kotlin/org/entur/ror/ubelluris/file/FileService.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/file/FileService.kt
@@ -5,7 +5,7 @@ import com.google.cloud.storage.StorageOptions
 import org.entur.ror.ubelluris.config.GcsConfig
 import java.nio.file.Path
 
-class UbellurisBucketService(
+class FileService(
     private val config: GcsConfig,
     private val storageProvider: () -> Storage = {
         StorageOptions
@@ -17,11 +17,28 @@ class UbellurisBucketService(
 ) {
     fun createStorage(): Storage = storageProvider()
 
+    fun createFetcher(
+        stopPlaceBlobPath: String,
+        timetableBlobPaths: Map<String, String>,
+    ): FileFetcher {
+        if (config.downloadEnabled) {
+            val storage = createStorage()
+            return GcsFileFetcher(
+                storage = storage,
+                config = config,
+                stopPlaceBlobPath = stopPlaceBlobPath,
+                timetableBlobPaths = timetableBlobPaths,
+            )
+        }
+
+        return LocalFileFetcher(stopPlaceBlobPath, timetableBlobPaths)
+    }
+
     fun createPublisher(
         storagePath: Path,
         localCachePath: Path,
     ): FilePublisher {
-        if (config.gcsEnabled) {
+        if (config.uploadEnabled) {
             val storage = createStorage()
             return GcsFilePublisher(config, storage, storagePath)
         }

--- a/src/main/kotlin/org/entur/ror/ubelluris/file/GcsFileFetcher.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/file/GcsFileFetcher.kt
@@ -6,17 +6,22 @@ import com.google.cloud.storage.Storage
 import com.google.cloud.storage.transfermanager.ParallelDownloadConfig
 import com.google.cloud.storage.transfermanager.TransferManagerConfig
 import com.google.cloud.storage.transfermanager.TransferStatus
+import org.entur.ror.ubelluris.config.GcsConfig
 import org.slf4j.LoggerFactory
 import java.nio.file.Files
 import java.nio.file.Path
 
 class GcsFileFetcher(
     private val storage: Storage,
-    private val inputBucketName: String,
+    private val config: GcsConfig,
     private val stopPlaceBlobPath: String,
     private val timetableBlobPaths: Map<String, String>,
-    private val downloadDir: Path = Path.of("downloads"),
+    private val downloadDir: Path = DEFAULT_DOWNLOAD_DIR,
 ) : FileFetcher {
+    companion object {
+        val DEFAULT_DOWNLOAD_DIR: Path = Path.of("downloads")
+    }
+
     private val logger = LoggerFactory.getLogger(javaClass)
     private val targetStopPlaceFile = "sweden_stop_places.xml"
 
@@ -56,19 +61,19 @@ class GcsFileFetcher(
         val missingBlobs =
             allBlobPaths
                 .filter { !Files.exists(downloadDir.resolve(it)) }
-                .map { BlobInfo.newBuilder(BlobId.of(inputBucketName, it)).build() }
+                .map { BlobInfo.newBuilder(BlobId.of(config.inputBucketName, it)).build() }
 
         if (missingBlobs.isEmpty()) {
             logger.info("All blobs already cached locally, skipping download")
             return
         }
 
-        logger.info("Downloading ${missingBlobs.size} blob(s) in parallel from $inputBucketName")
+        logger.info("Downloading ${missingBlobs.size} blob(s) in parallel from ${config.inputBucketName}")
 
         val downloadConfig =
             ParallelDownloadConfig
                 .newBuilder()
-                .setBucketName(inputBucketName)
+                .setBucketName(config.inputBucketName)
                 .setDownloadDirectory(downloadDir)
                 .build()
 

--- a/src/main/kotlin/org/entur/ror/ubelluris/file/LocalFileFetcher.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/file/LocalFileFetcher.kt
@@ -1,0 +1,15 @@
+package org.entur.ror.ubelluris.file
+
+import java.nio.file.Path
+
+class LocalFileFetcher(
+    private val stopPlaceBlobPath: String,
+    private val timetableBlobPaths: Map<String, String>,
+    private val downloadDir: Path = GcsFileFetcher.DEFAULT_DOWNLOAD_DIR,
+) : FileFetcher {
+    override fun fetch(): FileFetchResult =
+        FileFetchResult(
+            stopPlacePath = downloadDir.resolve(stopPlaceBlobPath),
+            timetablePaths = timetableBlobPaths.mapValues { (_, blobPath) -> downloadDir.resolve(blobPath) },
+        )
+}

--- a/src/test/kotlin/org/entur/ror/ubelluris/config/GcsConfigTest.kt
+++ b/src/test/kotlin/org/entur/ror/ubelluris/config/GcsConfigTest.kt
@@ -11,10 +11,12 @@ class GcsConfigTest {
                 projectId = "test-project",
                 outputBucketName = "test-bucket",
                 inputBucketName = "test-input-bucket",
-                gcsEnabled = true,
+                uploadEnabled = true,
+                downloadEnabled = true,
             )
 
-        assertThat(config.gcsEnabled).isEqualTo(true)
+        assertThat(config.uploadEnabled).isEqualTo(true)
+        assertThat(config.downloadEnabled).isEqualTo(true)
         assertThat(config.projectId).isEqualTo("test-project")
         assertThat(config.outputBucketName).isEqualTo("test-bucket")
         assertThat(config.inputBucketName).isEqualTo("test-input-bucket")

--- a/src/test/kotlin/org/entur/ror/ubelluris/file/GcsFileFetcherTest.kt
+++ b/src/test/kotlin/org/entur/ror/ubelluris/file/GcsFileFetcherTest.kt
@@ -2,6 +2,7 @@ package org.entur.ror.ubelluris.file
 
 import com.google.cloud.storage.Storage
 import org.assertj.core.api.Assertions.assertThat
+import org.entur.ror.ubelluris.config.GcsConfig
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.mockito.kotlin.mock
@@ -16,6 +17,14 @@ class GcsFileFetcherTest {
     lateinit var tempDir: Path
 
     private val storage: Storage = mock()
+    private val config =
+        GcsConfig(
+            projectId = "",
+            outputBucketName = "",
+            inputBucketName = "test-bucket",
+            uploadEnabled = false,
+            downloadEnabled = true,
+        )
 
     @Test
     fun shouldExtractStopPlaceXmlFromZip() {
@@ -27,7 +36,7 @@ class GcsFileFetcherTest {
         val fetcher =
             GcsFileFetcher(
                 storage = storage,
-                inputBucketName = "test-bucket",
+                config = config,
                 stopPlaceBlobPath = stopPlaceBlobPath,
                 timetableBlobPaths = emptyMap(),
                 downloadDir = tempDir,
@@ -61,7 +70,7 @@ class GcsFileFetcherTest {
         val fetcher =
             GcsFileFetcher(
                 storage = storage,
-                inputBucketName = "test-bucket",
+                config = config,
                 stopPlaceBlobPath = stopPlaceBlobPath,
                 timetableBlobPaths =
                     mapOf(
@@ -96,7 +105,7 @@ class GcsFileFetcherTest {
         val fetcher =
             GcsFileFetcher(
                 storage = storage,
-                inputBucketName = "test-bucket",
+                config = config,
                 stopPlaceBlobPath = stopPlaceBlobPath,
                 timetableBlobPaths = emptyMap(),
                 downloadDir = tempDir,

--- a/src/test/kotlin/org/entur/ror/ubelluris/file/GcsFilePublisherTest.kt
+++ b/src/test/kotlin/org/entur/ror/ubelluris/file/GcsFilePublisherTest.kt
@@ -24,6 +24,7 @@ class GcsFilePublisherTest {
             "test-bucket",
             "test-input-bucket",
             true,
+            true,
         )
 
     private val mockStorage: Storage = mock()


### PR DESCRIPTION
Instead of one GcsEnabled for both download and upload, itroduced one for each for more fine grained control of GCS interactions Introduced basic LocalFileFetcher aswell so fetcher and publishers follow the same pattern

BREAKING CHANGE: Renamed GCS_BUCKET_NAME to GCS_OUTPUT_BUCKET to be more specfic