### PR TITLE
feat/filter-asterix-public-code: Keep quays with public code *

### DIFF
--- a/data/cli-config.json
+++ b/data/cli-config.json
@@ -4,14 +4,17 @@
   "timetableProviders": [
     "vt",
     "halland",
-    "skane"
+    "skane",
+    "sj"
   ],
   "transportModes": [
     "tram",
     "water"
   ],
   "illegalPublicCodes": [
-    "*",
     "-"
+  ],
+  "filterPublicCodes": [
+    "*"
   ]
 }

--- a/src/main/kotlin/org/entur/ror/ubelluris/config/CliConfig.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/config/CliConfig.kt
@@ -9,6 +9,7 @@ data class CliConfig(
     var targetCodespace: String,
     var timetableProviders: List<String> = listOf("vt", "halland", "skane"),
     var transportModes: List<TransportMode> = listOf(TransportMode.TRAM, TransportMode.WATER),
-    val illegalPublicCodes: List<String> = listOf("*", "-"),
+    val illegalPublicCodes: List<String> = listOf("-"),
+    val filterPublicCodes: List<String> = listOf("*"),
     val resultsDir: String = "results",
 )

--- a/src/main/kotlin/org/entur/ror/ubelluris/filter/StandardImportFilterConfig.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/filter/StandardImportFilterConfig.kt
@@ -84,7 +84,7 @@ class StandardImportFilterConfig(
                         ),
                     "/PublicationDelivery/dataObjects/SiteFrame/stopPlaces/StopPlace/quays/Quay/PublicCode" to
                         PublicCodeFilterHandler(
-                            cliConfig.illegalPublicCodes,
+                            cliConfig.illegalPublicCodes + cliConfig.filterPublicCodes,
                         ),
                     "/PublicationDelivery/dataObjects/SiteFrame/stopPlaces/StopPlace/quays/Quay/PrivateCode"
                         to TextTrimmingHandler(),

--- a/src/main/kotlin/org/entur/ror/ubelluris/sax/handlers/PublicCodeFilterHandler.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/sax/handlers/PublicCodeFilterHandler.kt
@@ -5,7 +5,7 @@ import org.entur.netex.tools.lib.output.XMLElementHandler
 import org.xml.sax.Attributes
 
 class PublicCodeFilterHandler(
-    private val illegalPublicCodes: List<String>,
+    private val filterPublicCodes: List<String>,
 ) : XMLElementHandler {
     override fun startElement(
         uri: String?,
@@ -30,7 +30,7 @@ class PublicCodeFilterHandler(
 
         val text = String(ch, start, length).trim()
 
-        if (text in illegalPublicCodes) {
+        if (text in filterPublicCodes) {
             val empty = "".toCharArray()
             writer.characters(empty, 0, 0)
         } else {

--- a/src/test/kotlin/org/entur/ror/ubelluris/config/CliConfigTest.kt
+++ b/src/test/kotlin/org/entur/ror/ubelluris/config/CliConfigTest.kt
@@ -34,6 +34,8 @@ class CliConfigTest {
         assertThat(config.transportModes)
             .containsExactly(TransportMode.TRAM, TransportMode.WATER)
         assertThat(config.illegalPublicCodes)
-            .containsExactly("*", "-")
+            .containsExactly("-")
+        assertThat(config.filterPublicCodes)
+            .containsExactly("*")
     }
 }

--- a/src/test/kotlin/org/entur/ror/ubelluris/config/JsonConfigTest.kt
+++ b/src/test/kotlin/org/entur/ror/ubelluris/config/JsonConfigTest.kt
@@ -12,7 +12,8 @@ class JsonConfigTest {
             {
               "sourceCodespace": "SE:050",
               "targetCodespace": "SAM",
-              "illegalPublicCodes": ["*", "-"]
+              "illegalPublicCodes": ["-"]
+              "filterPublicCodes": ["*"]
             }
             """.trimIndent()
 
@@ -22,7 +23,8 @@ class JsonConfigTest {
         assertThat(config.targetCodespace).isEqualTo("SAM")
         assertThat(config.timetableProviders).containsExactly("vt", "halland", "skane")
         assertThat(config.transportModes).containsExactly(TransportMode.TRAM, TransportMode.WATER)
-        assertThat(config.illegalPublicCodes).containsExactly("*", "-")
+        assertThat(config.illegalPublicCodes).containsExactly("-")
+        assertThat(config.filterPublicCodes).containsExactly("*")
     }
 
     @Test

--- a/src/test/kotlin/org/entur/ror/ubelluris/sax/selectors/entities/StopPlacePurgingEntitySelectorTest.kt
+++ b/src/test/kotlin/org/entur/ror/ubelluris/sax/selectors/entities/StopPlacePurgingEntitySelectorTest.kt
@@ -45,18 +45,6 @@ class StopPlacePurgingEntitySelectorTest {
     @Test
     fun shouldRemoveStopPlaceWithSingleQuayWithIllegalPublicCode() {
         val stopPlace = defaultEntity(id = "stopPlace1", type = NetexTypes.STOP_PLACE)
-        repository.addQuayToStopPlace("stopPlace1", QuayData("quay1", "*"))
-
-        setupEntities(mapOf(NetexTypes.STOP_PLACE to mapOf("stopPlace1" to stopPlace)))
-
-        val result = selector.selectEntities(context)
-
-        assertThat(result.selection[NetexTypes.STOP_PLACE]).isEmpty()
-    }
-
-    @Test
-    fun shouldRemoveStopPlaceWithSingleQuayWithDashPublicCode() {
-        val stopPlace = defaultEntity(id = "stopPlace1", type = NetexTypes.STOP_PLACE)
         repository.addQuayToStopPlace("stopPlace1", QuayData("quay1", "-"))
 
         setupEntities(mapOf(NetexTypes.STOP_PLACE to mapOf("stopPlace1" to stopPlace)))
@@ -192,7 +180,7 @@ class StopPlacePurgingEntitySelectorTest {
     @Test
     fun shouldKeepStopPlaceWithMultipleQuaysEvenWhenOneHasIllegalPublicCode() {
         val stopPlace = defaultEntity(id = "stopPlace1", type = NetexTypes.STOP_PLACE)
-        repository.addQuayToStopPlace("stopPlace1", QuayData("quay1", "*"))
+        repository.addQuayToStopPlace("stopPlace1", QuayData("quay1", "-"))
         repository.addQuayToStopPlace("stopPlace1", QuayData("quay2", "A"))
 
         setupEntities(mapOf(NetexTypes.STOP_PLACE to mapOf("stopPlace1" to stopPlace)))


### PR DESCRIPTION
SJ uses several of the quays with public code *, so instead of removing the quays we just leave the public code field empty. This introduces the illegal and filtered public codes config to seperate which codes are deleted and which are just filtered(aka changed to empty).