### PR TITLE
feat/drop-multi-modal: Drop parent stops when configured

### DIFF
--- a/data/cli-config.json
+++ b/data/cli-config.json
@@ -13,5 +13,6 @@
   "illegalPublicCodes": [
     "*",
     "-"
-  ]
+  ],
+  "dropMultiModal": true
 }

--- a/data/cli-config.json
+++ b/data/cli-config.json
@@ -14,5 +14,5 @@
     "*",
     "-"
   ],
-  "dropMultiModal": true
+  "dropParentStops": true
 }

--- a/src/main/kotlin/org/entur/ror/ubelluris/config/CliConfig.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/config/CliConfig.kt
@@ -11,4 +11,5 @@ data class CliConfig(
     var transportModes: List<TransportMode> = listOf(TransportMode.TRAM, TransportMode.WATER),
     val illegalPublicCodes: List<String> = listOf("*", "-"),
     val resultsDir: String = "results",
+    val dropMultiModal: Boolean = false,
 )

--- a/src/main/kotlin/org/entur/ror/ubelluris/config/CliConfig.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/config/CliConfig.kt
@@ -11,5 +11,5 @@ data class CliConfig(
     var transportModes: List<TransportMode> = listOf(TransportMode.TRAM, TransportMode.WATER),
     val illegalPublicCodes: List<String> = listOf("*", "-"),
     val resultsDir: String = "results",
-    val dropMultiModal: Boolean = false,
+    val dropParentStops: Boolean = false,
 )

--- a/src/main/kotlin/org/entur/ror/ubelluris/filter/StandardImportFilterConfig.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/filter/StandardImportFilterConfig.kt
@@ -101,7 +101,7 @@ class StandardImportFilterConfig(
                 ),
             ).withEntitySelectors(
                 listOf(
-                    StopPlacePurgingEntitySelector(stopPlacePurgingRepository),
+                    StopPlacePurgingEntitySelector(stopPlacePurgingRepository, cliConfig.dropMultiModal),
                 ),
             ).withRefSelectors(listOf(StopPlacePurgingRefSelector()))
             .withRemovePrivateData(true)

--- a/src/main/kotlin/org/entur/ror/ubelluris/filter/StandardImportFilterConfig.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/filter/StandardImportFilterConfig.kt
@@ -101,7 +101,7 @@ class StandardImportFilterConfig(
                 ),
             ).withEntitySelectors(
                 listOf(
-                    StopPlacePurgingEntitySelector(stopPlacePurgingRepository, cliConfig.dropMultiModal),
+                    StopPlacePurgingEntitySelector(stopPlacePurgingRepository, cliConfig.dropParentStops),
                 ),
             ).withRefSelectors(listOf(StopPlacePurgingRefSelector()))
             .withRemovePrivateData(true)

--- a/src/main/kotlin/org/entur/ror/ubelluris/sax/selectors/entities/StopPlacePurgingEntitySelector.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/sax/selectors/entities/StopPlacePurgingEntitySelector.kt
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory
 
 class StopPlacePurgingEntitySelector(
     val stopPlacePurgingRepository: StopPlacePurgingRepository,
-    val dropMultiModal: Boolean,
+    val dropParentStops: Boolean,
 ) : EntitySelector {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -56,7 +56,7 @@ class StopPlacePurgingEntitySelector(
 
                             // Remove stop places with no quays
                             if (remainingQuays.isEmpty()) {
-                                if (dropMultiModal) {
+                                if (dropParentStops) {
                                     // TODO: Add log statement of dropping multi-modal stop place, needs improved logging branch
                                     stopPlacesToRemove.add(entity.key)
                                     return@filter false

--- a/src/main/kotlin/org/entur/ror/ubelluris/sax/selectors/entities/StopPlacePurgingEntitySelector.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/sax/selectors/entities/StopPlacePurgingEntitySelector.kt
@@ -57,7 +57,10 @@ class StopPlacePurgingEntitySelector(
                             // Remove stop places with no quays
                             if (remainingQuays.isEmpty()) {
                                 if (dropParentStops) {
-                                    // TODO: Add log statement of dropping multi-modal stop place, needs improved logging branch
+                                    logger.debug(
+                                        "Removing stop place {} that is a parent because dropParentStops is toggled on",
+                                        kv(STOP_PLACE_ID, entity.key),
+                                    )
                                     stopPlacesToRemove.add(entity.key)
                                     return@filter false
                                 }

--- a/src/main/kotlin/org/entur/ror/ubelluris/sax/selectors/entities/StopPlacePurgingEntitySelector.kt
+++ b/src/main/kotlin/org/entur/ror/ubelluris/sax/selectors/entities/StopPlacePurgingEntitySelector.kt
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory
 
 class StopPlacePurgingEntitySelector(
     val stopPlacePurgingRepository: StopPlacePurgingRepository,
+    val dropMultiModal: Boolean,
 ) : EntitySelector {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -55,6 +56,12 @@ class StopPlacePurgingEntitySelector(
 
                             // Remove stop places with no quays
                             if (remainingQuays.isEmpty()) {
+                                if (dropMultiModal) {
+                                    // TODO: Add log statement of dropping multi-modal stop place, needs improved logging branch
+                                    stopPlacesToRemove.add(entity.key)
+                                    return@filter false
+                                }
+
                                 // Child stop place with no quays
                                 if (stopPlacePurgingRepository.isChildStopPlace(entity.key)) {
                                     stopPlacesToRemove.add(entity.key)

--- a/src/test/kotlin/org/entur/ror/ubelluris/sax/selectors/entities/StopPlacePurgingEntitySelectorTest.kt
+++ b/src/test/kotlin/org/entur/ror/ubelluris/sax/selectors/entities/StopPlacePurgingEntitySelectorTest.kt
@@ -14,7 +14,7 @@ import org.mockito.kotlin.whenever
 
 class StopPlacePurgingEntitySelectorTest {
     private val repository = StopPlacePurgingRepository()
-    private val selector = StopPlacePurgingEntitySelector(repository)
+    private val selector = StopPlacePurgingEntitySelector(repository, false)
 
     private val context = mock<EntitySelectorContext>()
     private val entityModel = mock<EntityModel>()
@@ -245,6 +245,66 @@ class StopPlacePurgingEntitySelectorTest {
 
         assertThat(result.selection[NetexTypes.QUAY]).isEmpty()
         assertThat(result.selection[NetexTypes.STOP_PLACE]).isEmpty()
+    }
+
+    @Test
+    fun shouldRemoveParentStopPlaceWithNoQuaysWhenDropMultiModalIsTrue() {
+        val dropMultiModalSelector = StopPlacePurgingEntitySelector(repository, dropMultiModal = true)
+        val parentStopPlace = defaultEntity(id = "parentStop", type = NetexTypes.STOP_PLACE)
+        val child1 = defaultEntity(id = "child1", type = NetexTypes.STOP_PLACE)
+        val child2 = defaultEntity(id = "child2", type = NetexTypes.STOP_PLACE)
+
+        repository.addChildStopToParent("parentStop", "child1")
+        repository.addChildStopToParent("parentStop", "child2")
+        repository.addQuayToStopPlace("child1", QuayData("quay1", "A"))
+        repository.addQuayToStopPlace("child2", QuayData("quay2", "B"))
+
+        setupEntities(
+            mapOf(
+                NetexTypes.STOP_PLACE to
+                    mapOf(
+                        "parentStop" to parentStopPlace,
+                        "child1" to child1,
+                        "child2" to child2,
+                    ),
+            ),
+        )
+
+        val result = dropMultiModalSelector.selectEntities(context)
+
+        assertThat(result.selection[NetexTypes.STOP_PLACE]).doesNotContainKey("parentStop")
+        assertThat(result.selection[NetexTypes.STOP_PLACE]).containsKey("child1")
+        assertThat(result.selection[NetexTypes.STOP_PLACE]).containsKey("child2")
+    }
+
+    @Test
+    fun shouldKeepParentStopPlaceWithNoQuaysWhenDropMultiModalIsFalse() {
+        val keepMultiModalSelector = StopPlacePurgingEntitySelector(repository, dropMultiModal = false)
+        val parentStopPlace = defaultEntity(id = "parentStop", type = NetexTypes.STOP_PLACE)
+        val child1 = defaultEntity(id = "child1", type = NetexTypes.STOP_PLACE)
+        val child2 = defaultEntity(id = "child2", type = NetexTypes.STOP_PLACE)
+
+        repository.addChildStopToParent("parentStop", "child1")
+        repository.addChildStopToParent("parentStop", "child2")
+        repository.addQuayToStopPlace("child1", QuayData("quay1", "A"))
+        repository.addQuayToStopPlace("child2", QuayData("quay2", "B"))
+
+        setupEntities(
+            mapOf(
+                NetexTypes.STOP_PLACE to
+                    mapOf(
+                        "parentStop" to parentStopPlace,
+                        "child1" to child1,
+                        "child2" to child2,
+                    ),
+            ),
+        )
+
+        val result = keepMultiModalSelector.selectEntities(context)
+
+        assertThat(result.selection[NetexTypes.STOP_PLACE]).containsKey("parentStop")
+        assertThat(result.selection[NetexTypes.STOP_PLACE]).containsKey("child1")
+        assertThat(result.selection[NetexTypes.STOP_PLACE]).containsKey("child2")
     }
 
     @Test

--- a/src/test/kotlin/org/entur/ror/ubelluris/sax/selectors/entities/StopPlacePurgingEntitySelectorTest.kt
+++ b/src/test/kotlin/org/entur/ror/ubelluris/sax/selectors/entities/StopPlacePurgingEntitySelectorTest.kt
@@ -248,8 +248,8 @@ class StopPlacePurgingEntitySelectorTest {
     }
 
     @Test
-    fun shouldRemoveParentStopPlaceWithNoQuaysWhenDropMultiModalIsTrue() {
-        val dropMultiModalSelector = StopPlacePurgingEntitySelector(repository, dropMultiModal = true)
+    fun shouldRemoveParentStopPlaceWithNoQuaysWhendropParentStopsIsTrue() {
+        val dropParentStopsSelector = StopPlacePurgingEntitySelector(repository, dropParentStops = true)
         val parentStopPlace = defaultEntity(id = "parentStop", type = NetexTypes.STOP_PLACE)
         val child1 = defaultEntity(id = "child1", type = NetexTypes.STOP_PLACE)
         val child2 = defaultEntity(id = "child2", type = NetexTypes.STOP_PLACE)
@@ -270,7 +270,7 @@ class StopPlacePurgingEntitySelectorTest {
             ),
         )
 
-        val result = dropMultiModalSelector.selectEntities(context)
+        val result = dropParentStopsSelector.selectEntities(context)
 
         assertThat(result.selection[NetexTypes.STOP_PLACE]).doesNotContainKey("parentStop")
         assertThat(result.selection[NetexTypes.STOP_PLACE]).containsKey("child1")
@@ -278,8 +278,8 @@ class StopPlacePurgingEntitySelectorTest {
     }
 
     @Test
-    fun shouldKeepParentStopPlaceWithNoQuaysWhenDropMultiModalIsFalse() {
-        val keepMultiModalSelector = StopPlacePurgingEntitySelector(repository, dropMultiModal = false)
+    fun shouldKeepParentStopPlaceWithNoQuaysWhendropParentStopsIsFalse() {
+        val keepMultiModalSelector = StopPlacePurgingEntitySelector(repository, dropParentStops = false)
         val parentStopPlace = defaultEntity(id = "parentStop", type = NetexTypes.STOP_PLACE)
         val child1 = defaultEntity(id = "child1", type = NetexTypes.STOP_PLACE)
         val child2 = defaultEntity(id = "child2", type = NetexTypes.STOP_PLACE)


### PR DESCRIPTION
Remove handling of multi modal stops by removing parent stops by config untill the downstream applications support multi modal stops. This should fix data quality issues caused by missing multi modal support in down stream applications.